### PR TITLE
Implement Visual Multiplier Indicator to Beatmap Stats.

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,16 +261,16 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     if (cache.bpm !== beatmap.stats.bpm.realtime) {
       const bpmBox = document.getElementsByClassName('BPM')[0];
       const bpmValue = document.getElementById('bpm');
+      const { min, max } = beatmap.stats.bpm;
 
-      if (beatmap.stats.bpm.min !== beatmap.stats.bpm.max) {
-        const threshold = 5/100;
-        if ( beatmap.stats.bpm.realtime < beatmap.stats.bpm.min + threshold) {
-          bpmBox.style.color = '#ff6666';
-        } else if (beatmap.stats.bpm.realtime > beatmap.stats.bpm.max - threshold) {
-          bpmBox.style.color = '#b2ff66';
-        }
-      } else bpmBox.style.color = '#FEFFB8';
+      let color = '#FEFFB8';
+      if (min !== max) {
+        const threshold = (max - min) * 0.25;
+        if (beatmap.stats.bpm.realtime < beatmap.stats.bpm.min + threshold) color = '#b2ff66';
+        if (beatmap.stats.bpm.realtime > beatmap.stats.bpm.max - threshold) color = '#ff6666';
+      }
 
+      bpmBox.style.color = color;
       cache.bpm = beatmap.stats.bpm.realtime;
       bpmValue.innerHTML = beatmap.stats.bpm.realtime;
     }

--- a/index.js
+++ b/index.js
@@ -291,8 +291,18 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.ar !== beatmap.stats.ar.converted) {
+      const arBox = document.getElementsByClassName('AR')[0];
+      const arValue = document.getElementById('ar');
+
+      let arBoxTextColor = '#ffffff';
+      if (beatmap.stats.ar.original !== beatmap.stats.ar.converted) {
+        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+        arBoxTextColor = beatmap.stats.ar.converted > beatmap.stats.ar.original ? '#ff6666' : '#b2ff66';
+      }
+
+      arBox.style.color = arBoxTextColor;
       cache.ar = beatmap.stats.ar.converted;
-      document.getElementById('ar').innerHTML = beatmap.stats.ar.converted;
+      arValue.innerHTML = beatmap.stats.ar.converted;
     }
 
     if (cache.od !== beatmap.stats.od.converted) {

--- a/index.js
+++ b/index.js
@@ -306,8 +306,18 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.od !== beatmap.stats.od.converted) {
+      const odBox = document.getElementsByClassName('OD')[0];
+      const odValue = document.getElementById('od');
+
+      let odBoxTextColor = '#ffffff';
+      if (beatmap.stats.od.original !== beatmap.stats.od.converted) {
+        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+        odBoxTextColor = beatmap.stats.od.converted > beatmap.stats.od.original ? '#ff6666' : '#b2ff66';
+      }
+
+      odBox.style.color = odBoxTextColor;
       cache.od = beatmap.stats.od.converted;
-      document.getElementById('od').innerHTML = beatmap.stats.od.converted;
+      odValue.innerHTML = beatmap.stats.od.converted;
     }
 
     if (cache.hp !== beatmap.stats.hp.converted) {

--- a/index.js
+++ b/index.js
@@ -321,8 +321,18 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.hp !== beatmap.stats.hp.converted) {
+      const hpBox = document.getElementsByClassName('HP')[0];
+      const hpValue = document.getElementById('hp');
+
+      let hpBoxTextColor = '#ffffff';
+      if (beatmap.stats.hp.original !== beatmap.stats.hp.converted) {
+        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+        hpBoxTextColor = beatmap.stats.hp.converted > beatmap.stats.hp.original ? '#ff6666' : '#b2ff66';
+      }
+
+      hpBox.style.color = hpBoxTextColor;
       cache.hp = beatmap.stats.hp.converted;
-      document.getElementById('hp').innerHTML = beatmap.stats.hp.converted;
+      hpValue.innerHTML = beatmap.stats.hp.converted;
     }
 
     if (cache.maxSR !== beatmap.stats.stars.total) {

--- a/index.js
+++ b/index.js
@@ -289,7 +289,6 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       let csBoxTextColor = '#ffffff';
       if (MultiplierColorEnabled) {
         if (beatmap.stats.cs.original !== beatmap.stats.cs.converted) {
-          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
           csBoxTextColor = beatmap.stats.cs.converted > beatmap.stats.cs.original ? '#ff6666' : '#b2ff66';
         }
       }
@@ -306,7 +305,6 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       let arBoxTextColor = '#ffffff';
       if (MultiplierColorEnabled) {
         if (beatmap.stats.ar.original !== beatmap.stats.ar.converted) {
-          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
           arBoxTextColor = beatmap.stats.ar.converted > beatmap.stats.ar.original ? '#ff6666' : '#b2ff66';
         }
       }
@@ -323,7 +321,6 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       let odBoxTextColor = '#ffffff';
       if (MultiplierColorEnabled) {
         if (beatmap.stats.od.original !== beatmap.stats.od.converted) {
-          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
           odBoxTextColor = beatmap.stats.od.converted > beatmap.stats.od.original ? '#ff6666' : '#b2ff66';
         }
       }
@@ -340,7 +337,6 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       let hpBoxTextColor = '#ffffff';
       if (MultiplierColorEnabled) {
         if (beatmap.stats.hp.original !== beatmap.stats.hp.converted) {
-          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
           hpBoxTextColor = beatmap.stats.hp.converted > beatmap.stats.hp.original ? '#ff6666' : '#b2ff66';
         }
       }

--- a/index.js
+++ b/index.js
@@ -259,8 +259,20 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.bpm !== beatmap.stats.bpm.realtime) {
+      const bpmBox = document.getElementsByClassName('BPM')[0];
+      const bpmValue = document.getElementById('bpm');
+
+      if (beatmap.stats.bpm.min !== beatmap.stats.bpm.max) {
+        const threshold = 5/100;
+        if ( beatmap.stats.bpm.realtime < beatmap.stats.bpm.min + threshold) {
+          bpmBox.style.color = '#ff6666';
+        } else if (beatmap.stats.bpm.realtime > beatmap.stats.bpm.max - threshold) {
+          bpmBox.style.color = '#b2ff66';
+        }
+      } else bpmBox.style.color = '#FEFFB8';
+
       cache.bpm = beatmap.stats.bpm.realtime;
-      document.getElementById('bpm').innerHTML = beatmap.stats.bpm.realtime;
+      bpmValue.innerHTML = beatmap.stats.bpm.realtime;
     }
 
     if (cache.cs !== beatmap.stats.cs.converted) {

--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
 
       csBox.style.color = csBoxTextColor;
       cache.cs = beatmap.stats.cs.converted;
-      csValue.innerHTML = beatmap.stats.cs.converted;
+      csValue.innerHTML = beatmap.stats.cs.converted.toFixed(1);
     }
 
     if (cache.ar !== beatmap.stats.ar.converted) {
@@ -302,7 +302,7 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
 
       arBox.style.color = arBoxTextColor;
       cache.ar = beatmap.stats.ar.converted;
-      arValue.innerHTML = beatmap.stats.ar.converted;
+      arValue.innerHTML = beatmap.stats.ar.converted.toFixed(1);
     }
 
     if (cache.od !== beatmap.stats.od.converted) {
@@ -317,7 +317,7 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
 
       odBox.style.color = odBoxTextColor;
       cache.od = beatmap.stats.od.converted;
-      odValue.innerHTML = beatmap.stats.od.converted;
+      odValue.innerHTML = beatmap.stats.od.converted.toFixed(1);
     }
 
     if (cache.hp !== beatmap.stats.hp.converted) {
@@ -332,7 +332,7 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
 
       hpBox.style.color = hpBoxTextColor;
       cache.hp = beatmap.stats.hp.converted;
-      hpValue.innerHTML = beatmap.stats.hp.converted;
+      hpValue.innerHTML = beatmap.stats.hp.converted.toFixed(1);
     }
 
     if (cache.maxSR !== beatmap.stats.stars.total) {

--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       cache.maxSR = beatmap.stats.stars.total;
       let sr = document.getElementById('sr');
       let srTextColor = beatmap.stats.stars.total >= 6.5 ? '#fd5' : '#000000';
-      sr.innerHTML = beatmap.stats.stars.total;
+      sr.innerHTML = beatmap.stats.stars.total.toFixed(2);
       sr.style.color = srTextColor;
       document.getElementById('srStar').contentDocument.getElementsByTagName('svg')[0].style.fill = srTextColor;
       document.getElementById('srCont').style.backgroundColor = getDiffColour(cache.maxSR);

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function renderGraph(graphData) {
   chartLighter.update();
 }
 
-
+let MultiplierColorEnabled;
 
 socket.sendCommand('getSettings', encodeURI(window.COUNTER_PATH));
 socket.commands((data) => {
@@ -192,6 +192,10 @@ socket.commands((data) => {
       document.body.style.setProperty('--missColor', message['MissColor']);
     };
 
+    if (message["MultiplierColorEnabled"] != null) {
+      MultiplierColorEnabled = message["MultiplierColorEnabled"];
+    }
+
   } catch (error) {
     console.log(error);
   };
@@ -259,15 +263,18 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.bpm !== beatmap.stats.bpm.realtime) {
-      const bpmBox = document.getElementsByClassName('BPM')[0];
       const bpmValue = document.getElementById('bpm');
-      const { min, max } = beatmap.stats.bpm;
+      const bpmBox = document.getElementsByClassName('BPM')[0];
 
       let color = '#FEFFB8';
-      if (min !== max) {
-        const threshold = (max - min) * 0.25;
-        if (beatmap.stats.bpm.realtime < beatmap.stats.bpm.min + threshold) color = '#b2ff66';
-        if (beatmap.stats.bpm.realtime > beatmap.stats.bpm.max - threshold) color = '#ff6666';
+      if (MultiplierColorEnabled) {
+        const { min, max } = beatmap.stats.bpm;
+
+        if (min !== max) {
+          const threshold = (max - min) * 0.25;
+          if (beatmap.stats.bpm.realtime < beatmap.stats.bpm.min + threshold) color = '#b2ff66';
+          if (beatmap.stats.bpm.realtime > beatmap.stats.bpm.max - threshold) color = '#ff6666';
+        }
       }
 
       bpmBox.style.color = color;
@@ -280,9 +287,11 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       const csValue = document.getElementById('cs');
 
       let csBoxTextColor = '#ffffff';
-      if (beatmap.stats.cs.original !== beatmap.stats.cs.converted) {
-        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
-        csBoxTextColor = beatmap.stats.cs.converted > beatmap.stats.cs.original ? '#ff6666' : '#b2ff66';
+      if (MultiplierColorEnabled) {
+        if (beatmap.stats.cs.original !== beatmap.stats.cs.converted) {
+          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+          csBoxTextColor = beatmap.stats.cs.converted > beatmap.stats.cs.original ? '#ff6666' : '#b2ff66';
+        }
       }
 
       csBox.style.color = csBoxTextColor;
@@ -295,9 +304,11 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       const arValue = document.getElementById('ar');
 
       let arBoxTextColor = '#ffffff';
-      if (beatmap.stats.ar.original !== beatmap.stats.ar.converted) {
-        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
-        arBoxTextColor = beatmap.stats.ar.converted > beatmap.stats.ar.original ? '#ff6666' : '#b2ff66';
+      if (MultiplierColorEnabled) {
+        if (beatmap.stats.ar.original !== beatmap.stats.ar.converted) {
+          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+          arBoxTextColor = beatmap.stats.ar.converted > beatmap.stats.ar.original ? '#ff6666' : '#b2ff66';
+        }
       }
 
       arBox.style.color = arBoxTextColor;
@@ -310,9 +321,11 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       const odValue = document.getElementById('od');
 
       let odBoxTextColor = '#ffffff';
-      if (beatmap.stats.od.original !== beatmap.stats.od.converted) {
-        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
-        odBoxTextColor = beatmap.stats.od.converted > beatmap.stats.od.original ? '#ff6666' : '#b2ff66';
+      if (MultiplierColorEnabled) {
+        if (beatmap.stats.od.original !== beatmap.stats.od.converted) {
+          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+          odBoxTextColor = beatmap.stats.od.converted > beatmap.stats.od.original ? '#ff6666' : '#b2ff66';
+        }
       }
 
       odBox.style.color = odBoxTextColor;
@@ -325,9 +338,11 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
       const hpValue = document.getElementById('hp');
 
       let hpBoxTextColor = '#ffffff';
-      if (beatmap.stats.hp.original !== beatmap.stats.hp.converted) {
-        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
-        hpBoxTextColor = beatmap.stats.hp.converted > beatmap.stats.hp.original ? '#ff6666' : '#b2ff66';
+      if (MultiplierColorEnabled) {
+        if (beatmap.stats.hp.original !== beatmap.stats.hp.converted) {
+          // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+          hpBoxTextColor = beatmap.stats.hp.converted > beatmap.stats.hp.original ? '#ff6666' : '#b2ff66';
+        }
       }
 
       hpBox.style.color = hpBoxTextColor;

--- a/index.js
+++ b/index.js
@@ -276,8 +276,18 @@ socket.api_v2(({play, beatmap, directPath, folders, performance, state, resultsS
     }
 
     if (cache.cs !== beatmap.stats.cs.converted) {
+      const csBox = document.getElementsByClassName('CS')[0];
+      const csValue = document.getElementById('cs');
+
+      let csBoxTextColor = '#ffffff';
+      if (beatmap.stats.cs.original !== beatmap.stats.cs.converted) {
+        // Colors extracted from the osu!lazer mods menu's multiplier indicator.
+        csBoxTextColor = beatmap.stats.cs.converted > beatmap.stats.cs.original ? '#ff6666' : '#b2ff66';
+      }
+
+      csBox.style.color = csBoxTextColor;
       cache.cs = beatmap.stats.cs.converted;
-      document.getElementById('cs').innerHTML = beatmap.stats.cs.converted;
+      csValue.innerHTML = beatmap.stats.cs.converted;
     }
 
     if (cache.ar !== beatmap.stats.ar.converted) {

--- a/settings.json
+++ b/settings.json
@@ -38,8 +38,15 @@
         "uniqueID": "GraphColor",
         "type": "color",
         "title": "Graph Color",
-        "description": "Note: this doesn't work yet.\nChange the color of the strain graph.",
+        "description": "Change the color of the strain graph.",
         "value": "#B9EAFF"
+    },
+    {
+      "uniqueID": "MultiplierColorEnabled",
+      "type": "checkbox",
+      "title": "Dynamic statistic colors",
+      "description": "Dynamically change the beatmap statistic colors based on mods or bpm shifts.",
+      "value": "Enabled"
     },
     {
         "uniqueID": "GradientColor1",
@@ -89,12 +96,5 @@
         "title": "Miss Color Indicator",
         "description": "Change the color of the indicator of the miss marker.",
         "value": "#F06363"
-    },
-    {
-      "uniqueID": "MultiplierColorEnabled",
-      "type": "checkbox",
-      "title": "Multiplier Stats Color",
-      "description": "Toggle the color change of the beatmap stats based on the multiplier.",
-      "value": "Enabled"
     }
 ]

--- a/settings.json
+++ b/settings.json
@@ -89,5 +89,12 @@
         "title": "Miss Color Indicator",
         "description": "Change the color of the indicator of the miss marker.",
         "value": "#F06363"
+    },
+    {
+      "uniqueID": "MultiplierColorEnabled",
+      "type": "checkbox",
+      "title": "Multiplier Stats Color",
+      "description": "Toggle the color change of the beatmap stats based on the multiplier.",
+      "value": "Enabled"
     }
 ]

--- a/styles/style.css
+++ b/styles/style.css
@@ -222,10 +222,6 @@ svg {
     font-size: 14px;
 }
 
-.BPM p {
-    color: #FEFFB8;
-}
-
 .BPM #bpm {
     -webkit-mask: linear-gradient(to top, transparent 5%, black 20%, black 80%, transparent 95%);
     mask: linear-gradient(to top, transparent 5%, black 20%, black 80%, transparent 95%);
@@ -234,7 +230,6 @@ svg {
 .BPM span {
     transition: ease-in-out 300ms;
     font-size: 14px !important;
-    color: #FEFFB8;
 }
 
 .Right {


### PR DESCRIPTION
This PR adds code that computedly changes the color of each individual beatmap stat (both label and value) depending on the multiplier applied by the mods.
The colors have been chosen from the osu!lazer mods menu. (green when the multiplier is under 1x and red when multiplier is above 1x)

For `CS`, `AR`, `OD` & `HP`, the color is changing whenever the converted value differs from the original.
For `BPM`, the color change only happens when the real-time bpm is close to the minimum or maximum values.

This PR also makes all of values mentioned (except BPM) to always show a floating number, with 1 decimal. (for UI consistency)

https://github.com/user-attachments/assets/969bacb4-18ba-43b3-b387-4d6934054b54

https://github.com/user-attachments/assets/ecc67fda-9593-4e9f-9467-67240f6c2cbd



